### PR TITLE
Define folder structure of OSeMOSYS implementations

### DIFF
--- a/OSeMOSYS_example/README.md
+++ b/OSeMOSYS_example/README.md
@@ -23,6 +23,24 @@ in the contents of the `OSeMOSYS_example` folder.
 The implementation should be runnable from the command line, taking the input
 location, and output location as arguments.
 
+For example, create a script which runs your implementation with any pre- and post- processing.
+
+```bash
+INPUT_LOCATION=$1
+OUTPUT_LOCATION=$1
+src/pre-processing.sh $INPUT_DATA > data/pre_processed.dat
+src/my_implementation.sh data/pre_processed.dat > data/results.dat
+src/post_processing.sh data/results.dat $OUTPUT_LOCATION
+```
+
+This script could then be called as follows:
+
+```bash
+run.sh ./my_project/input_data ./my_project/results
+```
+
+You may like to use a Makefile to run the pipeline of pre-processing -> run the model -> post-process the results.
+
 ### Ensure that your implementation can read and run the example models
 
 The example model definitions can be found in `./examples`.

--- a/OSeMOSYS_example/README.md
+++ b/OSeMOSYS_example/README.md
@@ -11,6 +11,8 @@ OSeMOSYS_example $ tree
 │   └── index.md
 └── scripts
     └── README.md
+├── src
+    └── README.md
 ```
 
 ## Creating a new implementation
@@ -56,7 +58,7 @@ When you have finished creating your new implementation of OSeMOSYS, submit a
 pull request at http://github.com/OSeMOSYS/OSeMOSYS in which you add your
 implementation as a submodule.
 
-For example, first [fork](https://github.com/OSeMOSYS/OSeMOSYS/fork) 
+For example, first [fork](https://github.com/OSeMOSYS/OSeMOSYS/fork)
 the OSeMOSYS code on Github. Then, add your implementation
 as a submodule, and push your changes to your fork:
 

--- a/OSeMOSYS_example/README.md
+++ b/OSeMOSYS_example/README.md
@@ -28,9 +28,9 @@ For example, create a script which runs your implementation with any pre- and po
 ```bash
 INPUT_LOCATION=$1
 OUTPUT_LOCATION=$1
-src/pre-processing.sh $INPUT_DATA > data/pre_processed.dat
+scripts/pre-processing.sh $INPUT_DATA > data/pre_processed.dat
 src/my_implementation.sh data/pre_processed.dat > data/results.dat
-src/post_processing.sh data/results.dat $OUTPUT_LOCATION
+scripts/post_processing.sh data/results.dat $OUTPUT_LOCATION
 ```
 
 This script could then be called as follows:

--- a/OSeMOSYS_example/README.md
+++ b/OSeMOSYS_example/README.md
@@ -1,0 +1,58 @@
+# Example OSeMOSYS Implementation
+
+This folder demonstrates the required structure for implementations of the
+OSeMOSYS formulation.
+
+```bash
+OSeMOSYS_example $ tree
+.
+├── README.md
+├── docs
+│   └── index.md
+└── scripts
+    └── README.md
+```
+
+## Creating a new implementation
+
+Create a new git repository containing your OSeMOSYS implementation, and copy
+in the contents of the `OSeMOSYS_example` folder.
+
+### Ensure your implementation can be run from the command line
+
+The implementation should be runnable from the command line, taking the input
+location, and output location as arguments.
+
+### Ensure that your implementation can read and run the example models
+
+The example model definitions can be found in `./examples`.
+
+### Ensure that your implementation writes results in the common format
+
+Implementations should write their results into the common format detailed in
+the documentation.
+
+## Adding your implementation to the main OSeMOSYS repository
+
+When you have finished creating your new implementation of OSeMOSYS, submit a
+pull request at http://github.com/OSeMOSYS/OSeMOSYS in which you add your
+implementation as a submodule.
+
+For example, first [fork](https://github.com/OSeMOSYS/OSeMOSYS/fork) 
+the OSeMOSYS code on Github. Then, add your implementation
+as a submodule, and push your changes to your fork:
+
+```bash
+git clone http://github.com/my_name/OSeMOSYS # clone the main repository
+git branch my_implementation
+git checkout my_implementation
+git add submodule http://github.com/my_name/my_implementation OSeMOSYS_my_implementation
+git push
+```
+
+Finally submit a pull request.
+
+As part of the process of reviewing a new implementation of OSeMOSYS, we need to
+setup the continuous integration tests to check that the results from running the
+example model files match those of the other implementations. This is due to the
+principle of harmonisation between OSeMOSYS implementations.

--- a/OSeMOSYS_example/docs/index.md
+++ b/OSeMOSYS_example/docs/index.md
@@ -1,0 +1,5 @@
+# Example OSeMOSYS Implementation
+
+This folder demonstrates the required structure for implementations of the
+OSeMOSYS formulation.
+

--- a/OSeMOSYS_example/scripts/README.md
+++ b/OSeMOSYS_example/scripts/README.md
@@ -1,0 +1,6 @@
+# Scripts folder
+
+Add any scripts to this folder which are used to pre-process input data,
+run your implementation, or post-process results.
+
+Document the scripts in this readme.

--- a/OSeMOSYS_example/src/README.md
+++ b/OSeMOSYS_example/src/README.md
@@ -1,0 +1,3 @@
+# Source code folder
+
+This folder should contain the actual OSeMOSYS implementation code

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSeMOSYS - Open Source Energy Modelling System
 
-[![Build Status](https://travis-ci.com/KTH-dESA/OSeMOSYS.svg?branch=master)](https://travis-ci.com/KTH-dESA/OSeMOSYS)
+[![Build Status](https://travis-ci.com/OSeMOSYS/OSeMOSYS.svg?branch=master)](https://travis-ci.com/OSeMOSYS/OSeMOSYS)
 [![Documentation Status](https://readthedocs.org/projects/osemosys/badge/?version=latest)](https://osemosys.readthedocs.io/en/latest/?badge=latest)
 
 Welcome to OSeMOSYS - the open source energy modelling system. This source code


### PR DESCRIPTION
First stab at addressing #56

Adds an `OSeMOSYS_example` folder to the main repository which documents the expected structure of the language implementations. 

@abhishek0208 and @tniet - we can use this pull request as an opportunity to discuss what we think is needed to close issue #56:

- is this an appropriate structure for all language implementations?
- is the information provided in the readme sufficient (at the moment)
- any remaining work should be noted in new issues if it is not added in this pull request