### PR TITLE
Update Create a model in OSeMOSYS.rst

### DIFF
--- a/docs/manual/Create a model in OSeMOSYS.rst
+++ b/docs/manual/Create a model in OSeMOSYS.rst
@@ -243,7 +243,7 @@ Once Xcode is installed, agree to the licence and open it (Xcode will be found i
 ------------------------------------------
 - If you get the message below, type the following line and press Enter: 
 
-	**brew install homebrew/science/glpk**:
+	**brew install glpk**:
 
 .. figure::  documents/img/MAC4.png
    :align:   center
@@ -254,7 +254,7 @@ You should now have GLPK Installed
 
 - Type: **/usr/local/Cellar**
 
-In the folder glpk/4.64/bin you will find the glpsol program. 
+In the folder glpk/4.65/bin you will find the glpsol program. 
 
 - Create a folder called OSEMOSYS on your Desktop and copy the glpsol program into it. 
 


### PR DESCRIPTION
I got the error `Error: homebrew/science was deprecated. This tap is now empty as all its formulae were migrated.`, it seems the install works with `brew install glpk` [https://formulae.brew.sh/formula/glpk](https://formulae.brew.sh/formula/glpk).

The location stays the same :
```
$ brew list glpk
/usr/local/Cellar/glpk/4.65/bin/glpsol
/usr/local/Cellar/glpk/4.65/include/glpk.h
/usr/local/Cellar/glpk/4.65/lib/libglpk.40.dylib
/usr/local/Cellar/glpk/4.65/lib/ (2 other files)
```