### PR TITLE
Add link to the original OSeMOSYS paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 Welcome to OSeMOSYS - the Open Source energy MOdelling SYStem. This source code
 repository contains the Apache-2.0 licensed source-code for the different
 implementations of OSeMOSYS - GNU MathProg, Pyomo, PuLP and GAMS.
+
+For an in-depth introduction to the underlying model and its structure, you can
+read the [original paper](https://www.sciencedirect.com/science/article/abs/pii/S0301421511004897)
+(needs access to Elsevier ScienceDirect).
+
 The different versions are contained in subfolders, together with readme files
 which provide information of how to install and run the code.
 


### PR DESCRIPTION
To newcomers to the project OSeMOSYS, the original paper
is a good introduction to the structure of the model.

The code described in the paper is slighlt outdated by now but
the underlying model has stayed mostly the same and the
paper is a good resource for people wanting to have a deeper
understanding of the model.

One argument against having the link as part of the README
is that it needs a paid access to ScienceDirect. But I think that
most of the modeling community has ways to access it through
their institutions so maybe it's not an issue?